### PR TITLE
Adding stroke number to rowing extension

### DIFF
--- a/src/main/java/com/sweetzpot/tcxextensions/SZRowingTrackpoint.java
+++ b/src/main/java/com/sweetzpot/tcxextensions/SZRowingTrackpoint.java
@@ -11,13 +11,6 @@ public class SZRowingTrackpoint implements TCXExtension {
     private final SZRawForce rawForce;
     private SZStrokeNumber strokeNumber;
 
-    public SZRowingTrackpoint(SZAcceleration acceleration, SZSpeed speed, SZStrokeRate strokeRate, SZRawForce rawForce) {
-        this.acceleration = acceleration;
-        this.speed = speed;
-        this.strokeRate = strokeRate;
-        this.rawForce = rawForce;
-    }
-
     public SZRowingTrackpoint(SZAcceleration acceleration, SZSpeed speed, SZStrokeRate strokeRate, SZRawForce rawForce, SZStrokeNumber strokeNumber) {
         this.acceleration = acceleration;
         this.speed = speed;

--- a/src/main/java/com/sweetzpot/tcxextensions/SZRowingTrackpoint.java
+++ b/src/main/java/com/sweetzpot/tcxextensions/SZRowingTrackpoint.java
@@ -9,12 +9,21 @@ public class SZRowingTrackpoint implements TCXExtension {
     private final SZSpeed speed;
     private final SZStrokeRate strokeRate;
     private final SZRawForce rawForce;
+    private SZStrokeNumber strokeNumber;
 
     public SZRowingTrackpoint(SZAcceleration acceleration, SZSpeed speed, SZStrokeRate strokeRate, SZRawForce rawForce) {
         this.acceleration = acceleration;
         this.speed = speed;
         this.strokeRate = strokeRate;
         this.rawForce = rawForce;
+    }
+
+    public SZRowingTrackpoint(SZAcceleration acceleration, SZSpeed speed, SZStrokeRate strokeRate, SZRawForce rawForce, SZStrokeNumber strokeNumber) {
+        this.acceleration = acceleration;
+        this.speed = speed;
+        this.strokeRate = strokeRate;
+        this.rawForce = rawForce;
+        this.strokeNumber = strokeNumber;
     }
 
     @Override
@@ -24,6 +33,7 @@ public class SZRowingTrackpoint implements TCXExtension {
         if(speed != null) speed.serialize(serializer);
         if(strokeRate != null) strokeRate.serialize(serializer);
         if(rawForce != null) rawForce.serialize(serializer);
+        if(strokeNumber != null) strokeNumber.serialize(serializer);
         serializer.print("</SZRowing>");
     }
 }

--- a/src/main/java/com/sweetzpot/tcxextensions/SZStrokeNumber.java
+++ b/src/main/java/com/sweetzpot/tcxextensions/SZStrokeNumber.java
@@ -1,0 +1,19 @@
+package com.sweetzpot.tcxextensions;
+
+
+import com.sweetzpot.tcxzpot.Serializer;
+import com.sweetzpot.tcxzpot.TCXSerializable;
+
+public class SZStrokeNumber implements TCXSerializable {
+
+    private int number;
+
+    public static SZStrokeNumber strokeNumber(int number){ return new SZStrokeNumber(number); }
+
+    public SZStrokeNumber(int number){ this.number = number; }
+
+    @Override
+    public void serialize(Serializer serializer) {
+        serializer.print("<StrokeNumber>" + number + "</StrokeNumber>");
+    }
+}

--- a/src/main/java/com/sweetzpot/tcxextensions/builders/SZRowingTrackpointBuilder.java
+++ b/src/main/java/com/sweetzpot/tcxextensions/builders/SZRowingTrackpointBuilder.java
@@ -8,6 +8,7 @@ public class SZRowingTrackpointBuilder {
     private SZSpeed speed;
     private SZRawForce rawForce;
     private SZStrokeRate strokeRate;
+    private SZStrokeNumber strokeNumber = SZStrokeNumber.strokeNumber(-1);
 
     public static SZRowingTrackpointBuilder rowing() {
         return new SZRowingTrackpointBuilder();
@@ -35,7 +36,12 @@ public class SZRowingTrackpointBuilder {
         return this;
     }
 
+    public SZRowingTrackpointBuilder withStrokeNumber(SZStrokeNumber strokeNumber) {
+        this.strokeNumber = strokeNumber;
+        return this;
+    }
+
     public SZRowingTrackpoint build() {
-        return new SZRowingTrackpoint(acceleration, speed, strokeRate, rawForce);
+        return new SZRowingTrackpoint(acceleration, speed, strokeRate, rawForce, strokeNumber);
     }
 }

--- a/src/main/java/com/sweetzpot/tcxextensions/builders/SZRowingTrackpointBuilder.java
+++ b/src/main/java/com/sweetzpot/tcxextensions/builders/SZRowingTrackpointBuilder.java
@@ -8,7 +8,7 @@ public class SZRowingTrackpointBuilder {
     private SZSpeed speed;
     private SZRawForce rawForce;
     private SZStrokeRate strokeRate;
-    private SZStrokeNumber strokeNumber = SZStrokeNumber.strokeNumber(-1);
+    private SZStrokeNumber strokeNumber = null;
 
     public static SZRowingTrackpointBuilder rowing() {
         return new SZRowingTrackpointBuilder();

--- a/src/test/java/com/sweetzpot/tcxextensions/SZRowingTrackpointTest.java
+++ b/src/test/java/com/sweetzpot/tcxextensions/SZRowingTrackpointTest.java
@@ -29,7 +29,6 @@ public class SZRowingTrackpointTest {
         verify(speed).serialize(serializer);
         verify(strokeRate).serialize(serializer);
         verify(rawForce).serialize(serializer);
-        verify(serializer).print("<StrokeNumber>-1</StrokeNumber>");
         verify(serializer).print("</SZRowing>");
     }
 

--- a/src/test/java/com/sweetzpot/tcxextensions/SZRowingTrackpointTest.java
+++ b/src/test/java/com/sweetzpot/tcxextensions/SZRowingTrackpointTest.java
@@ -29,6 +29,33 @@ public class SZRowingTrackpointTest {
         verify(speed).serialize(serializer);
         verify(strokeRate).serialize(serializer);
         verify(rawForce).serialize(serializer);
+        verify(serializer).print("<StrokeNumber>-1</StrokeNumber>");
+        verify(serializer).print("</SZRowing>");
+    }
+
+    @Test
+    public void serializesToTCXFormatWithStrokeNumber() throws Exception {
+        Serializer serializer = mock(Serializer.class);
+        SZAcceleration acceleration = mock(SZAcceleration.class);
+        SZSpeed speed = mock(SZSpeed.class);
+        SZStrokeRate strokeRate = mock(SZStrokeRate.class);
+        SZRawForce rawForce = mock(SZRawForce.class);
+        SZStrokeNumber strokeNumber = mock(SZStrokeNumber.class);
+
+        rowing().withAcceleration(acceleration)
+                .withSpeed(speed)
+                .withStrokeRate(strokeRate)
+                .withRawForce(rawForce)
+                .withStrokeNumber(strokeNumber)
+                .build()
+                .serialize(serializer);
+
+        verify(serializer).print("<SZRowing xmlns=\"https://www.sweetzpot.com/xmlschemas/RowingExtension/v1\">");
+        verify(acceleration).serialize(serializer);
+        verify(speed).serialize(serializer);
+        verify(strokeRate).serialize(serializer);
+        verify(rawForce).serialize(serializer);
+        verify(strokeNumber).serialize(serializer);
         verify(serializer).print("</SZRowing>");
     }
 

--- a/src/test/java/com/sweetzpot/tcxextensions/SZStrokeNumberTest.java
+++ b/src/test/java/com/sweetzpot/tcxextensions/SZStrokeNumberTest.java
@@ -1,0 +1,21 @@
+package com.sweetzpot.tcxextensions;
+
+import com.sweetzpot.tcxzpot.Serializer;
+
+import org.junit.Test;
+
+import static com.sweetzpot.tcxextensions.SZStrokeNumber.strokeNumber;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SZStrokeNumberTest {
+
+    @Test
+    public void serializesToTCXFormat() throws Exception {
+        Serializer serializer = mock(Serializer.class);
+
+        strokeNumber(3).serialize(serializer);
+
+        verify(serializer).print("<StrokeNumber>3</StrokeNumber>");
+    }
+}


### PR DESCRIPTION
Adding field to specify to which stroke a trackpoint belongs (with a stroke number). 
Using a null stroke number by default so that it is optional and doesn't appear in the TCX file if no strokes have been detected or if this information wasn't added.   